### PR TITLE
Improve get_capacities

### DIFF
--- a/sardou/capacities.py
+++ b/sardou/capacities.py
@@ -1,17 +1,18 @@
-def _unwrap(v):
-    if isinstance(v, dict):
-        if "$primitive" in v:
-            return v["$primitive"]
-        if "$list" in v:
-            return [_unwrap(x) for x in v["$list"]]
-        if "$map" in v:
-            return {
-                _unwrap(entry["$key"]): _unwrap(
-                    {k: x for k, x in entry.items() if k != "$key"}
-                )
-                for entry in v["$map"]
-            }
-    return v
+def _unwrap(value):
+    if isinstance(value, dict):
+        if "$primitive" in value:
+            return value["$primitive"]
+        if "$list" in value:
+            return [_unwrap(item) for item in value["$list"]]
+        if "$map" in value:
+            return dict(_unwrap_map_entry(entry) for entry in value["$map"])
+    return value
+
+
+def _unwrap_map_entry(entry):
+    key = _unwrap(entry["$key"])
+    value = _unwrap({k: v for k, v in entry.items() if k != "$key"})
+    return key, value
 
 
 def _is_overall(node: dict) -> bool:

--- a/sardou/capacities.py
+++ b/sardou/capacities.py
@@ -29,41 +29,36 @@ def _get_res_key(node: dict) -> str:
 
 
 def extract_capacities(processed_nodes: dict):
-    flavour_definition = {}
     capacity_by = {}
     capacities = {}
     overall = None
 
-    for _, node in processed_nodes.items():
-        if _is_overall(node):
-            cap_props = (
-                node.get("capabilities", {}).get("capacity", {}).get("properties", {})
-                or {}
-            )
-            overall = {k: _unwrap(v) for k, v in cap_props.items()}
-            break
-
     for name, node in processed_nodes.items():
+        caps = node.get("capabilities", {}) or {}
         if _is_overall(node):
+            cap_props = caps.get("capacity", {}).get("properties", {})
+            overall = {k: _unwrap(v) for k, v in cap_props.items()}
             continue
 
-        caps = node.get("capabilities", {}) or {}
-        flavour_definition[name] = {}
+        res_key = _get_res_key(node)
+        capacities.setdefault(res_key, {})[name] = {}
         for cap_name, cap in caps.items():
             props = cap.get("properties", {}) or {}
             if props and cap_name != "capacity":
-                flavour_definition[name][cap_name] = {
+                capacities[res_key][name][cap_name] = {
                     k: _unwrap(v) for k, v in props.items()
                 }
 
-    if overall is not None:
-        capacities = {"flavour": flavour_definition, "capacity_raw": overall}
-    else:
-        for name, node in processed_nodes.items():
-            caps = node.get("capabilities", {}) or {}
-            inst = caps.get("capacity", {}).get("properties", {}).get("instances")
+        if overall is not None:
+            continue
+        inst = caps.get("capacity", {}).get("properties", {}).get("instances")
+        if res_key == "flavour":
             capacity_by[name] = _unwrap(inst) if inst is not None else 1
 
-        capacities = {"flavour": flavour_definition, "capacity_flavour": capacity_by}
+    if capacity_by:
+        capacities["capacity_flavour"] = capacity_by
+
+    if overall is not None:
+        capacities["capacity_raw"] = overall
 
     return capacities

--- a/sardou/capacities.py
+++ b/sardou/capacities.py
@@ -20,6 +20,14 @@ def _is_overall(node: dict) -> bool:
     return any("OverallCapacity" in type_name for type_name in types.keys())
 
 
+def _get_res_key(node: dict) -> str:
+    res_type = _unwrap(
+        node.get("capabilities", {}).get("resource", {}).get("properties", {}).get("type", {})
+    ) or ""
+
+    return "edge" if "edge" in res_type.lower() else "flavour"
+
+
 def extract_capacities(processed_nodes: dict):
     flavour_definition = {}
     capacity_by = {}

--- a/sardou/capacities.py
+++ b/sardou/capacities.py
@@ -1,3 +1,6 @@
+_CAPACITY_KEY = "capacity"
+
+
 def _unwrap(value):
     if isinstance(value, dict):
         if "$primitive" in value:
@@ -17,7 +20,7 @@ def _unwrap_map_entry(entry):
 
 def _is_overall(node: dict) -> bool:
     types = node.get("types") or {}
-    return any("OverallCapacity" in type_name for type_name in types.keys())
+    return any("OverallCapacity" in type_name for type_name in types)
 
 
 def _get_res_key(node: dict) -> str:
@@ -25,40 +28,42 @@ def _get_res_key(node: dict) -> str:
         node.get("capabilities", {}).get("resource", {}).get("properties", {}).get("type", {})
     ) or ""
 
-    return "edge" if "edge" in res_type.lower() else "flavour"
+    return "edge_instances" if "edge" in res_type.lower() else "cloud_flavours"
 
 
-def extract_capacities(processed_nodes: dict):
+def _process_node(name, node, capabilities, capacities, capacity_by):
+    res_key = _get_res_key(node)
+    capacities.setdefault(res_key, {})[name] = {}
+
+    for cap_name, capability in capabilities.items():
+        props = capability.get("properties", {}) or {}
+        if props and cap_name != _CAPACITY_KEY:
+            capacities[res_key][name][cap_name] = {
+                k: _unwrap(v) for k, v in props.items()
+            }
+
+    instances = capabilities.get(_CAPACITY_KEY, {}).get("properties", {}).get("instances")
+    if res_key == "cloud_flavours":
+        capacity_by[name] = _unwrap(instances) if instances is not None else 1
+
+
+def extract_capacities(processed_nodes: dict) -> dict:
     capacity_by = {}
     capacities = {}
     overall = None
 
     for name, node in processed_nodes.items():
-        caps = node.get("capabilities", {}) or {}
+        capabilities = node.get("capabilities", {}) or {}
         if _is_overall(node):
-            cap_props = caps.get("capacity", {}).get("properties", {})
+            cap_props = capabilities.get(_CAPACITY_KEY, {}).get("properties", {})
             overall = {k: _unwrap(v) for k, v in cap_props.items()}
             continue
 
-        res_key = _get_res_key(node)
-        capacities.setdefault(res_key, {})[name] = {}
-        for cap_name, cap in caps.items():
-            props = cap.get("properties", {}) or {}
-            if props and cap_name != "capacity":
-                capacities[res_key][name][cap_name] = {
-                    k: _unwrap(v) for k, v in props.items()
-                }
-
-        if overall is not None:
-            continue
-        inst = caps.get("capacity", {}).get("properties", {}).get("instances")
-        if res_key == "flavour":
-            capacity_by[name] = _unwrap(inst) if inst is not None else 1
-
-    if capacity_by:
-        capacities["capacity_flavour"] = capacity_by
+        _process_node(name, node, capabilities, capacities, capacity_by)
 
     if overall is not None:
-        capacities["capacity_raw"] = overall
+        capacities["cloud_capacity_raw"] = overall
+    elif capacity_by:
+        capacities["cloud_capacity_flavour"] = capacity_by
 
     return capacities

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -479,8 +479,8 @@ class TestExtractCapacities:
             )
         }
         result = extract(nodes)
-        assert "capacity_flavour" in result
-        assert result["capacity_flavour"]["small"] == 3
+        assert "cloud_capacity_flavour" in result
+        assert result["cloud_capacity_flavour"]["small"] == 3
 
     def test_overall_based_returns_capacity_raw(self, extract):
         nodes = {
@@ -490,8 +490,8 @@ class TestExtractCapacities:
             )
         }
         result = extract(nodes)
-        assert "capacity_raw" in result
-        assert result["capacity_raw"]["total"] == 100
+        assert "cloud_capacity_raw" in result
+        assert result["cloud_capacity_raw"]["total"] == 100
 
     def test_flavour_dict_populated(self, extract):
         nodes = {
@@ -501,12 +501,12 @@ class TestExtractCapacities:
             )
         }
         result = extract(nodes)
-        assert "medium" in result["flavour"]
-        assert result["flavour"]["medium"]["host"]["mem-size"] == "4"
+        assert "medium" in result["cloud_flavours"]
+        assert result["cloud_flavours"]["medium"]["host"]["mem-size"] == "4"
 
     def test_empty_nodes_returns_empty_flavour(self, extract):
         result = extract({})
-        assert result["flavour"] == {}
+        assert "cloud_flavours" not in result
 
     def test_overall_node_excluded_from_flavour(self, extract):
         nodes = {
@@ -516,7 +516,7 @@ class TestExtractCapacities:
             )
         }
         result = extract(nodes)
-        assert "overall" not in result["flavour"]
+        assert ("cloud_flavours" not in result) or ("overall" not in result["cloud_flavours"])
 
 
 # ---------------------------------------------------------------------------
@@ -555,7 +555,7 @@ class TestSardouCDTAPI:
     def test_get_capacities_returns_dict(self, cloud_overall, mode):
         caps = cloud_overall.get_capacities()
         assert isinstance(caps, dict)
-        assert "flavour" in caps
+        assert "cloud_flavours" in caps
 
     def test_get_capacities_raises_on_sat(self, mode):
         """get_capacities() must raise TypeError when called on a SAT."""
@@ -666,25 +666,51 @@ class TestSATTemplateOutput:
 class TestCDTTemplateOutput:
     """Verify that CDT templates produce meaningful, non-empty capacities."""
 
-    @pytest.fixture(params=["cloud-overall.yaml", "cloud-instances.yaml", "edge.yaml"])
+    @pytest.fixture(params=["cloud-overall.yaml", "cloud-instances.yaml"])
     def cdt(self, request, mode):
         return _load_sardou(CDT_DIR / request.param, mode)
+
+    @pytest.fixture()
+    def edge_cdt(self, mode):
+        return _load_sardou(CDT_DIR / "edge.yaml", mode)
 
     def test_capacities_non_empty(self, cdt, mode):
         caps = cdt.get_capacities()
         assert caps, "CDT should produce non-empty capacities"
 
-    def test_capacities_have_flavour(self, cdt, mode):
+    def test_capacities_have_cloud_flavours(self, cdt, mode):
         caps = cdt.get_capacities()
-        assert "flavour" in caps
-        assert caps["flavour"], "CDT flavour dict should be non-empty"
+        assert "cloud_flavours" in caps
+        assert caps["cloud_flavours"], "CDT cloud_flavours dict should be non-empty"
+
+    def test_edge_capacities_have_edge_instances(self, edge_cdt, mode):
+        caps = edge_cdt.get_capacities()
+        assert "edge_instances" in caps
+        assert caps["edge_instances"], "CDT edge_instances dict should be non-empty"
 
     def test_flavour_entries_have_properties(self, cdt, mode):
         caps = cdt.get_capacities()
-        for flavour_name, flavour in caps["flavour"].items():
+        for flavour_name, flavour in caps["cloud_flavours"].items():
             assert flavour, (
                 f"Flavour '{flavour_name}' should have at least one capability"
             )
+
+    def test_edge_flavour_entries_have_properties(self, edge_cdt, mode):
+        caps = edge_cdt.get_capacities()
+        for flavour_name, edge in caps["edge_instances"].items():
+            assert edge, f"Edge '{flavour_name}' should have at least one capability"
+
+    def test_cloud_flavour_capacity(self, cdt, mode):
+        caps = cdt.get_capacities()
+        assert caps.get("cloud_capacity_flavour") or caps.get("cloud_capacity_raw"), (
+            "Cloud CDT should have a cloud_capacity_"
+        )
+
+    def test_edge_flavour_capacity_is_empty(self, edge_cdt, mode):
+        caps = edge_cdt.get_capacities()
+        assert not caps.get("cloud_capacity_flavour"), (
+            "Edge CDT should not have cloud_capacity_flavour"
+        )
 
 
 @requires_puccini


### PR DESCRIPTION
This updates `get_capacities()` for capacity registration, separating edge and cloud and making it possible to handle mixed resource CDTs.

```
cloud_capacity_raw:
<amounts assigned to cloud by CPU,DISK, MEM>
cloud_capacity_flavour:
<amounts assigned to cloud flavours>
cloud_flavours:
<definition of cloud flavours>
edge_instances:
<definition of edge instances>
```